### PR TITLE
Added regex to Auth/RegisterController because of Stored XSS vulnerability.

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -48,7 +48,7 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => 'required|string|max:255',
+            'name' => 'required|string|max:255|regex:[A-Za-z1-9 ]',
             'email' => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:6|confirmed',
         ]);


### PR DESCRIPTION
I have added `regex:[A-Za-z1-9 ]` to the Validator function inside the RegisterController.php controller.

Without this regex in the validator a client could register with a username that allowed special characters, resulting in a stored XSS. The user name is stored in database from which even more damage could be done should there be malicious code being called by the XSS.