### PR TITLE
[User] Make the registered_at test case work properly.

### DIFF
--- a/tests/Unit/CommentTest.php
+++ b/tests/Unit/CommentTest.php
@@ -14,7 +14,7 @@ class CommentTest extends TestCase
     public function testPostedAt()
     {
         $comment = factory(Comment::class)->create();
-        $this->assertEquals($comment->posted_at->toDateTimeString(), now()->toDateTimeString());
+        $this->assertEqualsWithDelta($comment->posted_at->timestamp, now()->timestamp, 1);
     }
 
     public function testGettingOnlyLastWeekComments()

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -84,7 +84,7 @@ class UserTest extends TestCase
     public function testRegisteredAt()
     {
         $user = factory(User::class)->create();
-        $this->assertEquals($user->registered_at->toDateTimeString(), now()->toDateTimeString());
+        $this->assertEqualsWithDelta($user->registered_at->timestamp, now()->timestamp, 1);
     }
 
     public function testAuthorsScope()


### PR DESCRIPTION
Using the equals comparing is breaking some times.