### PR TITLE
Change the docker config to optimize for development on Mac machines.

### DIFF
--- a/.cloud/docker/Dockerfile.mac.dev
+++ b/.cloud/docker/Dockerfile.mac.dev
@@ -1,0 +1,46 @@
+FROM php:7.4-fpm
+LABEL maintainer="guillaumebriday@gmail.com"
+
+# Installing dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    default-mysql-client \
+    libpng-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
+    libmagickwand-dev \
+    libzip-dev \
+    libonig-dev \
+    locales \
+    zip \
+    vim \
+    jpegoptim optipng pngquant gifsicle \
+    nodejs npm \
+    && pecl install imagick \
+    pecl install xdebug
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install yarn(optional)
+npm install -g yarn
+
+# Installing extensions
+RUN docker-php-ext-install pdo_mysql mbstring zip exif pcntl bcmath opcache gd
+RUN docker-php-ext-enable imagick
+RUN docker-php-ext-enable xdebug; \
+    echo "error_reporting = E_ALL" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    echo "display_startup_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    echo "display_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+    echo "xdebug.remote_port = 9001" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
+
+
+# Installing composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Setting locales
+RUN echo fr_FR.UTF-8 UTF-8 > /etc/locale.gen && locale-gen
+
+# Changing Workdir
+WORKDIR /application

--- a/docker-compose.mac.dev.yml
+++ b/docker-compose.mac.dev.yml
@@ -1,0 +1,62 @@
+version: '3'
+
+services:
+  blog-server:
+    build: .cloud/docker
+    image: laravel-blog
+    depends_on:
+      - mysql
+      - mysql-test
+      - redis
+    volumes:
+      - ./:/application:delegated
+    environment:
+      XDEBUG_CONFIG: "remote_host=host.docker.internal"
+      PHP_IDE_CONFIG: "serverName={YOUR_SERVER_NAME}"
+
+  horizon:
+    build: .cloud/docker
+    image: laravel-blog
+    command: php artisan horizon
+    depends_on:
+      - mysql
+    volumes:
+      - ./:/application:delegated
+
+  mysql:
+    image: mysql:8
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=secret
+      - MYSQL_DATABASE=laravel-blog
+    volumes:
+      - db-data:/var/lib/mysql:delegated
+
+  mysql-test:
+    image: mysql:8
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - "3307:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=secret
+      - MYSQL_DATABASE=testing
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8000:8000"
+    volumes:
+      - .cloud/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:delegated
+      - ./:/application:delegated
+    depends_on:
+      - blog-server
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+
+volumes:
+  db-data:

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,12 @@ And then, compile the assets :
 $ docker run --rm -it -v $(pwd):/app -w /app node yarn dev
 ```
 
+Note: When developing on Mac, your file sync sometimes gets corrupted.
+You should run `yarn watch` directly inside the` blog-server` container and  the Dockerfile.dev file.
+```bash
+$ docker-compose run --rm blog-server yarn watch
+```
+
 Starting job for newsletter :
 ```bash
 $ docker-compose run blog-server php artisan tinker


### PR DESCRIPTION
- Add xdebug configs.
- Add `gd` lib use to testing upload image(UploadedFile::fake() func need it)
- Change file sync mode to `:delegated` [Refer](https://docs.docker.com/docker-for-mac/osxfs-caching/)
- You `yarn watch` directly inside `blog-server` container to remove syncing bundled js/css bundle file from `node` server in to `blog-server`